### PR TITLE
compatible with Windows Command Prompt

### DIFF
--- a/kanaquiz.py
+++ b/kanaquiz.py
@@ -799,7 +799,10 @@ def main(argv = None):
         if not os.path.exists(name):
             print('no history to display')
             return 1
-        os.system('less +G "%s"'%name)
+        if sys.platform.startswith('win'):
+            os.system('chcp 65001 > nul && more "%s"'%name)
+        else:
+            os.system('less +G "%s"'%name)
     return 0
 
 


### PR DESCRIPTION
Windows Command Prompt uses `more` instead of `less` to view the contents of a text file.